### PR TITLE
Building on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,6 +9,15 @@ instructions](https://www.tensorflow.org/install/).
 Ensure you have a recent version of bazel (>= 0.21.0) and JDK (>= 1.8). If not,
 follow [these directions](https://bazel.build/versions/master/docs/install.html).
 
+### (Optional) macOS Support
+
+If building on macOS, ensure you have [Homebrew](https://brew.sh) installed and
+install the necessary dependencies:
+
+```shell
+brew install coreutils gnu-sed
+```
+
 ### (virtualenv TensorFlow installation) Activate virtualenv
 
 If using virtualenv, activate your virtualenv for the rest of the installation,

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -40,7 +40,11 @@ function main() {
   # give us an absolute paths with tilde characters resolved to the destination
   # directory.
   mkdir -p ${DEST}
-  DEST=$(readlink -f "${DEST}")
+  if [[ $PLATFORM == 'darwin' ]]; then
+    DEST=$(greadlink -f "${DEST}")
+  else
+    DEST=$(readlink -f "${DEST}")
+  fi
   echo "=== destination directory: ${DEST}"
 
   TMPDIR=$(mktemp -d -t tmp.XXXXXXXXXX)

--- a/build_pip_pkg.sh
+++ b/build_pip_pkg.sh
@@ -40,11 +40,11 @@ function main() {
   # give us an absolute paths with tilde characters resolved to the destination
   # directory.
   mkdir -p ${DEST}
+  readlink="readlink"
   if [[ $PLATFORM == 'darwin' ]]; then
-    DEST=$(greadlink -f "${DEST}")
-  else
-    DEST=$(readlink -f "${DEST}")
+    readlink="greadlink"
   fi
+  DEST=$($readlink -f "${DEST}")
   echo "=== destination directory: ${DEST}"
 
   TMPDIR=$(mktemp -d -t tmp.XXXXXXXXXX)

--- a/trfl/op_gen_main.sh
+++ b/trfl/op_gen_main.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+
 set -e
 
 if [ "$#" -ne 2 ]; then
@@ -14,7 +16,12 @@ EOF
 
 for name in $(echo $2 | tr "," "\n")
 do
-    snake_name=`echo $name | sed 's/^[[:upper:]]/\L&/;s/[[:upper:]]/\L_&/g'`
+    sed="sed"
+    if [[ $PLATFORM == 'darwin' ]]; then
+        sed="gsed"
+    fi
+
+    snake_name=`echo $name | $sed 's/^[[:upper:]]/\L&/;s/[[:upper:]]/\L_&/g'`
     echo "$snake_name = _op_lib.$snake_name"
 done
 


### PR DESCRIPTION
**EDIT:** Fixed the issue and amended the pull request with the modifications, see https://github.com/deepmind/trfl/pull/12#issuecomment-471858294

------

**Background**
Due to the recent changes in the TRFL installation procedure, I ran into some issues running TRFL on macOS which broke my local TF dev environment. There were no [pre-built wheels](https://pypi.org/project/trfl/#files) for macOS, so I proceeded to attempt to build from source with some modifications to build on macOS.

**Environment Details**
- macOS 10.14.3
- Bazel 0.23.1
- TensorFlow 1.12
- TensorFlow Probability 0.5

**Changes & Issues**
The `build_pip_pkg.sh` script was updated to check for Darwin platforms, and instead use `greadlink -f` (from GNU Core Utils via Homebrew). No other changes were needed to proceed with the build.

The build seemingly went smoothly on macOS (and reproduced on a Linux/Ubuntu machine), see the full console outputs below. However, when importing TRFL using `import trfl`, I get the the error: `AttributeError: module '29f0280e24eacea242fe31b5dab40eba' has no attribute 'L_LL_ProjectL_Distribution'` (see trace below)

I am currently unable to pinpoint the source of the problem as I'm not sure if I am missing some underlying Linux-only assumption somewhere in the build process, so any help would be really appreciated!

**Stack Trace**
```
Traceback (most recent call last):
  File "experiment_agent.py", line 19, in <module>
    from agents.actor import Actor
  File "/Users/Abdel/Developer/code/agents/actor.py", line 9, in <module>
    import trfl
  File "/Users/Abdel/Developer/anaconda/lib/python3.6/site-packages/trfl/__init__.py", line 31, in <module>
    from trfl.dist_value_ops import categorical_dist_double_qlearning
  File "/Users/Abdel/Developer/anaconda/lib/python3.6/site-packages/trfl/dist_value_ops.py", line 33, in <module>
    from trfl import distribution_ops
  File "/Users/Abdel/Developer/anaconda/lib/python3.6/site-packages/trfl/distribution_ops.py", line 30, in <module>
    from trfl import gen_distribution_ops
  File "/Users/Abdel/Developer/anaconda/lib/python3.6/site-packages/trfl/gen_distribution_ops.py", line 3, in <module>
    L_LL_ProjectL_Distribution = _op_lib.L_LL_ProjectL_Distribution
AttributeError: module '29f0280e24eacea242fe31b5dab40eba' has no attribute 'L_LL_ProjectL_Distribution'
```

**Output of pip show -f trfl**
```
Name: trfl
Version: 1.0
Summary: trfl is a library of building blocks for reinforcement learning algorithms.
Home-page: http://www.github.com/deepmind/trfl/
Author: DeepMind
Author-email: trfl-steering@google.com
License: Apache 2.0
Location: /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages
Requires: dm-sonnet, absl-py, six, wrapt, numpy
Required-by:
Files:
  trfl-1.0.dist-info/INSTALLER
  trfl-1.0.dist-info/METADATA
  trfl-1.0.dist-info/RECORD
  trfl-1.0.dist-info/WHEEL
  trfl-1.0.dist-info/top_level.txt
  trfl/__init__.py
  trfl/__pycache__/__init__.cpython-36.pyc
  trfl/__pycache__/action_value_ops.cpython-36.pyc
  trfl/__pycache__/base_ops.cpython-36.pyc
  trfl/__pycache__/clipping_ops.cpython-36.pyc
  trfl/__pycache__/discrete_policy_gradient_ops.cpython-36.pyc
  trfl/__pycache__/dist_value_ops.cpython-36.pyc
  trfl/__pycache__/distribution_ops.cpython-36.pyc
  trfl/__pycache__/dpg_ops.cpython-36.pyc
  trfl/__pycache__/gen_distribution_ops.cpython-36.pyc
  trfl/__pycache__/indexing_ops.cpython-36.pyc
  trfl/__pycache__/periodic_ops.cpython-36.pyc
  trfl/__pycache__/pixel_control_ops.cpython-36.pyc
  trfl/__pycache__/policy_gradient_ops.cpython-36.pyc
  trfl/__pycache__/retrace_ops.cpython-36.pyc
  trfl/__pycache__/sequence_ops.cpython-36.pyc
  trfl/__pycache__/target_update_ops.cpython-36.pyc
  trfl/__pycache__/value_ops.cpython-36.pyc
  trfl/__pycache__/vtrace_ops.cpython-36.pyc
  trfl/_gen_distribution_ops.so
  trfl/action_value_ops.py
  trfl/base_ops.py
  trfl/clipping_ops.py
  trfl/discrete_policy_gradient_ops.py
  trfl/dist_value_ops.py
  trfl/distribution_ops.py
  trfl/dpg_ops.py
  trfl/gen_distribution_ops.py
  trfl/indexing_ops.py
  trfl/periodic_ops.py
  trfl/pixel_control_ops.py
  trfl/policy_gradient_ops.py
  trfl/retrace_ops.py
  trfl/sequence_ops.py
  trfl/target_update_ops.py
  trfl/value_ops.py
  trfl/vtrace_ops.py
```

**Console Output from Building TRFL**
```
in trfl/ on master
› ./configure.sh
rm: .bazelrc: No such file or directory
using installed tensorflow

in trfl/ on master
› bazel build -c opt :build_pip_pkg
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
WARNING: /private/var/tmp/_bazel_Abdel/75cbfa485f5681f3bc2b2ed75d0c5ecd/external/local_config_tf/BUILD:3504:1: target 'libtensorflow_framework.so' is both a rule and a file; please choose another name for the
 rule
WARNING: /private/var/tmp/_bazel_Abdel/75cbfa485f5681f3bc2b2ed75d0c5ecd/external/local_config_tf/BUILD:5:12: in hdrs attribute of cc_library rule @local_config_tf//:tf_header_lib: file '_api_implementation.so
' from target '@local_config_tf//:tf_header_include' is not allowed in hdrs
WARNING: /private/var/tmp/_bazel_Abdel/75cbfa485f5681f3bc2b2ed75d0c5ecd/external/local_config_tf/BUILD:5:12: in hdrs attribute of cc_library rule @local_config_tf//:tf_header_lib: file '_message.so' from targ
et '@local_config_tf//:tf_header_include' is not allowed in hdrs
INFO: Analysed target //:build_pip_pkg (18 packages loaded, 254 targets configured).
INFO: Found 1 target...
Target //:build_pip_pkg up-to-date:
  bazel-bin/build_pip_pkg
INFO: Elapsed time: 31.389s, Critical Path: 18.91s
INFO: 5 processes: 5 darwin-sandbox.
INFO: Build completed successfully, 11 total actions

in trfl/ on master
› mkdir /tmp/trfl_wheels

in trfl/ on master
› ./bazel-bin/build_pip_pkg /tmp/trfl_wheels
++ uname -s
++ tr A-Z a-z
+ PLATFORM=darwin
+ PIP_FILE_PREFIX=bazel-bin/build_pip_pkg.runfiles/__main__/
+ main /tmp/trfl_wheels
+ [[ ! -z /tmp/trfl_wheels ]]
+ [[ /tmp/trfl_wheels == \m\a\k\e ]]
+ DEST=/tmp/trfl_wheels
+ shift
+ [[ ! -z '' ]]
+ [[ -z /tmp/trfl_wheels ]]
+ mkdir -p /tmp/trfl_wheels
+ [[ darwin == \d\a\r\w\i\n ]]
++ greadlink -f /tmp/trfl_wheels
+ DEST=/private/tmp/trfl_wheels
+ echo '=== destination directory: /private/tmp/trfl_wheels'
=== destination directory: /private/tmp/trfl_wheels
++ mktemp -d -t tmp.XXXXXXXXXX
+ TMPDIR=/var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
++ date
+ echo Wed 6 Mar 2019 13:18:36 AEDT : '=== Using tmpdir: /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2'
Wed 6 Mar 2019 13:18:36 AEDT : === Using tmpdir: /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
+ echo '=== Copy TRFL files'
=== Copy TRFL files
+ cp bazel-bin/build_pip_pkg.runfiles/__main__/LICENSE /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
+ cp bazel-bin/build_pip_pkg.runfiles/__main__/MANIFEST.in /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
+ cp bazel-bin/build_pip_pkg.runfiles/__main__/setup.py /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
+ rsync -avm -L '--exclude=*_test.py' bazel-bin/build_pip_pkg.runfiles/__main__/trfl /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
building file list ... done
trfl/
trfl/__init__.py
trfl/_gen_distribution_ops.so
trfl/action_value_ops.py
trfl/base_ops.py
trfl/clipping_ops.py
trfl/discrete_policy_gradient_ops.py
trfl/dist_value_ops.py
trfl/distribution_ops.py
trfl/dpg_ops.py
trfl/gen_distribution_ops.py
trfl/indexing_ops.py
trfl/periodic_ops.py
trfl/pixel_control_ops.py
trfl/policy_gradient_ops.py
trfl/retrace_ops.py
trfl/sequence_ops.py
trfl/target_update_ops.py
trfl/value_ops.py
trfl/vtrace_ops.py

sent 210894 bytes  received 444 bytes  140892.00 bytes/sec
total size is 209421  speedup is 0.99
+ pushd /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
/var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2 ~/trfl
++ date
+ echo Wed 6 Mar 2019 13:18:37 AEDT : '=== Building wheel'
Wed 6 Mar 2019 13:18:37 AEDT : === Building wheel
+ python setup.py bdist_wheel
warning: no files found matching '*.dll' under directory 'trfl/'
warning: no files found matching '*.lib' under directory 'trfl/'
warning: no files found matching '*.pyd' under directory 'trfl/'
+ cp dist/trfl-1.0-cp36-cp36m-macosx_10_7_x86_64.whl /private/tmp/trfl_wheels
+ popd
~/trfl
+ rm -rf /var/folders/17/pgf9tjwd5_j4kml9hns8qfg80000gn/T/tmp.XXXXXXXXXX.Psy2xyC2
++ date
+ echo Wed 6 Mar 2019 13:18:38 AEDT : '=== Output wheel file is in: /private/tmp/trfl_wheels'
Wed 6 Mar 2019 13:18:38 AEDT : === Output wheel file is in: /private/tmp/trfl_wheels

in trfl/ on master
› pip install /tmp/trfl_wheels/*.whl
Processing /tmp/trfl_wheels/trfl-1.0-cp36-cp36m-macosx_10_7_x86_64.whl
Requirement already satisfied: six in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from trfl==1.0) (1.11.0)
Requirement already satisfied: dm-sonnet in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from trfl==1.0) (1.27)
Requirement already satisfied: absl-py in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from trfl==1.0) (0.2.0)
Requirement already satisfied: wrapt in /Users/Abdel/.local/lib/python3.6/site-packages (from trfl==1.0) (1.10.11)
Requirement already satisfied: numpy in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from trfl==1.0) (1.14.5)
Requirement already satisfied: semantic-version in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from dm-sonnet->trfl==1.0) (2.6.0)
Requirement already satisfied: contextlib2 in /Users/Abdel/Developer/anaconda/lib/python3.6/site-packages (from dm-sonnet->trfl==1.0) (0.5.5)
Installing collected packages: trfl
Successfully installed trfl-1.0
```