### PR TITLE
TF2: remove tf.contrib

### DIFF
--- a/trfl/discrete_policy_gradient_ops.py
+++ b/trfl/discrete_policy_gradient_ops.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 from trfl import base_ops
 from trfl import value_ops
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 DiscretePolicyEntropyExtra = collections.namedtuple(
     "discrete_policy_entropy_extra", ["entropy"])

--- a/trfl/discrete_policy_gradient_ops_test.py
+++ b/trfl/discrete_policy_gradient_ops_test.py
@@ -25,7 +25,7 @@ from six.moves import xrange  # pylint: disable=redefined-builtin
 import tensorflow as tf
 from trfl import discrete_policy_gradient_ops as pg_ops
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 
 class EntropyCostTest(parameterized.TestCase, tf.test.TestCase):

--- a/trfl/policy_gradient_ops.py
+++ b/trfl/policy_gradient_ops.py
@@ -25,6 +25,7 @@ from six.moves import zip
 import tensorflow as tf
 from trfl import base_ops
 from trfl import value_ops
+from tensorflow.python.util.nest import flatten_up_to
 
 nest = tf.nest
 
@@ -105,7 +106,7 @@ def policy_gradient_loss(policies, actions, action_values, policy_vars=None,
   """
   actions = nest.flatten(actions)
   if policy_vars:
-    policy_vars = nest.flatten_up_to(policies, policy_vars)
+    policy_vars = flatten_up_to(policies, policy_vars)
   else:
     policy_vars = [list()] * len(actions)
   policies = nest.flatten(policies)

--- a/trfl/policy_gradient_ops.py
+++ b/trfl/policy_gradient_ops.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 from trfl import base_ops
 from trfl import value_ops
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 PolicyEntropyExtra = collections.namedtuple("policy_entropy_extra", ["entropy"])
 SequenceA2CExtra = collections.namedtuple(

--- a/trfl/policy_gradient_ops_test.py
+++ b/trfl/policy_gradient_ops_test.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from trfl import policy_gradient_ops as pg_ops
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 
 class MockDistribution(object):

--- a/trfl/value_ops_test.py
+++ b/trfl/value_ops_test.py
@@ -23,7 +23,7 @@ from absl.testing import parameterized
 import tensorflow as tf
 from trfl import value_ops
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 
 class TDLearningTest(tf.test.TestCase):

--- a/trfl/vtrace_ops.py
+++ b/trfl/vtrace_ops.py
@@ -23,7 +23,7 @@ import collections
 # Dependency imports
 import tensorflow as tf
 
-nest = tf.contrib.framework.nest
+nest = tf.nest
 
 VTraceFromLogitsReturns = collections.namedtuple(
     'VTraceFromLogitsReturns',


### PR DESCRIPTION
Replaces the `tf.contrib.framework.nest` with `tf.nest`, which is compatible with `tensorflow==2.0.0-beta1`.