### PR TITLE
Fix legal_actions_mask bug in epsilon_greedy().

### DIFF
--- a/trfl/policy_ops_test.py
+++ b/trfl/policy_ops_test.py
@@ -105,6 +105,18 @@ class EpsilonGreedyTest(tf.test.TestCase):
     with self.test_session() as sess:
       self.assertAllClose(sess.run(result), expected)
 
+  def testLegalActionsMask2(self):
+    action_values = [-0.8, 1., -0.8, -2.0]
+    legal_actions_mask = [0., 0., 1., 1.]
+    epsilon = 0.1
+
+    expected = [0.00, 0.00, 0.95, 0.05]
+
+    result = policy_ops.epsilon_greedy(action_values, epsilon,
+                                       legal_actions_mask).probs
+    with self.test_session() as sess:
+      self.assertAllClose(sess.run(result), expected)
+
 
 if __name__ == "__main__":
   tf.test.main()


### PR DESCRIPTION
This PR addresses Issue https://github.com/deepmind/trfl/issues/27

Note that the bug must be addressed in two places. First, when selecting `max_value` - it must only be selected from legal actions. Second, when computing `greedy_probs` - there could be multiple action values achieving the max, but not all of them legal.

Also, I added `legal_actions_mask` to the list of values in the `tf.name_scope` context manager.

Aside from that, when there is no legal actions mask the `epsilon_greedy` function should execute exactly the same as before.

Happy to implement any small changes and if there’s a better fix altogether feel free to close this and implement it internally. Just thought I’d offer up a solution :)

